### PR TITLE
Auto corrected by following Lint Ruby Layout/HeredocIndentation

### DIFF
--- a/spec/synvert/core/rewriter/action/replace_with_action_spec.rb
+++ b/spec/synvert/core/rewriter/action/replace_with_action_spec.rb
@@ -31,10 +31,10 @@ module Synvert::Core
         send_node = Parser::CurrentRuby.parse(source)
         instance = double(current_node: send_node)
         Rewriter::ReplaceWithAction.new(instance, <<~EOS)
-            describe '#size' do
-              subject { super().size }
-              it { {{body}} }
-            end
+          describe '#size' do
+            subject { super().size }
+            it { {{body}} }
+          end
           EOS
       }
 


### PR DESCRIPTION
Auto corrected by following Lint Ruby Layout/HeredocIndentation

Click [here](https://awesomecode.io/repos/xinminlabs/synvert-core/lint_configs/ruby/69208) to configure it on awesomecode.io