### PR TITLE
Auto corrected by following Lint Ruby EmptyLine

### DIFF
--- a/lib/synvert/core/node_ext.rb
+++ b/lib/synvert/core/node_ext.rb
@@ -511,6 +511,7 @@ module Parser::AST
       when String
         if actual.is_a?(Parser::AST::Node)
           return true if (Parser::CurrentRuby.parse(expected) == actual rescue nil)
+
           actual.to_source == expected || (actual.to_source[0] == ':' && actual.to_source[1..-1] == expected) ||
             actual.to_source[1...-1] == expected
         else


### PR DESCRIPTION
Auto corrected by following Lint Ruby EmptyLine

Click [here](https://awesomecode.io/repos/xinminlabs/synvert-core/config_groups/ruby/371) to configure it on awesomecode.io