### PR TITLE
Auto corrected by following Lint Ruby Lint/AmbiguousOperatorPrecedence

### DIFF
--- a/lib/synvert/core/engine/erb.rb
+++ b/lib/synvert/core/engine/erb.rb
@@ -79,7 +79,7 @@ module Synvert::Core
           @newline_pending += 1
         else
           src << "@output_buffer.safe_append='"
-          src << "\n" * @newline_pending if @newline_pending > 0
+          src << ("\n" * @newline_pending) if @newline_pending > 0
           src << escape_text(text)
           src << "'.freeze;"
 


### PR DESCRIPTION
Auto corrected by following Lint Ruby Lint/AmbiguousOperatorPrecedence

Click [here](https://awesomecode.io/repos/xinminlabs/synvert-core-ruby/lint_configs/ruby/123764) to configure it on awesomecode.io