### PR TITLE
Auto corrected by following Lint Ruby Lint/RedundantStringCoercion

### DIFF
--- a/lib/synvert/core/node_query/compiler/selector.rb
+++ b/lib/synvert/core/node_query/compiler/selector.rb
@@ -34,7 +34,7 @@ module Synvert::Core::NodeQuery::Compiler
       str = ".#{@node_type}#{@attribute_list}"
       return str if !@index && !@has_expression
 
-      return "#{str}:has(#{@has_expression.to_s})" if @has_expression
+      return "#{str}:has(#{@has_expression})" if @has_expression
 
       case @index
       when 0


### PR DESCRIPTION
Auto corrected by following Lint Ruby Lint/RedundantStringCoercion

Click [here](https://awesomecode.io/repos/xinminlabs/synvert-core-ruby/lint_configs/ruby/69728) to configure it on awesomecode.io