### PR TITLE
Auto corrected by following Lint Ruby Lint/AmbiguousOperatorPrecedence

### DIFF
--- a/lib/synvert/core/rewriter/instance.rb
+++ b/lib/synvert/core/rewriter/instance.rb
@@ -413,7 +413,7 @@ module Synvert::Core
     # @param tab_size [Integer] tab size
     # @return [String]
     def add_leading_spaces(str, tab_size: 1)
-      " " * Configuration.tab_width * tab_size + str;
+      (" " * Configuration.tab_width * tab_size) + str;
     end
 
     private


### PR DESCRIPTION
Auto corrected by following Lint Ruby Lint/AmbiguousOperatorPrecedence

Click [here](https://awesomecode.io/repos/xinminlabs/synvert-core-ruby/lint_configs/ruby/123764) to configure it on awesomecode.io