### PR TITLE
Auto corrected by following Lint Ruby Lint/UnusedMethodArgument

### DIFF
--- a/lib/synvert/core/rewriter/instance.rb
+++ b/lib/synvert/core/rewriter/instance.rb
@@ -492,7 +492,7 @@ module Synvert::Core
     # @param file_path [String] file path
     # @param encoded_source [String] encoded source code
     # @return [Node] ast node for file
-    def parse_code_by_syntax_tree(file_path, encoded_source)
+    def parse_code_by_syntax_tree(_file_path, encoded_source)
       SyntaxTree::Parser.new(encoded_source).parse.statements
     end
   end


### PR DESCRIPTION
Auto corrected by following Lint Ruby Lint/UnusedMethodArgument

Click [here](https://awesomecode.io/repos/xinminlabs/synvert-core-ruby/lint_configs/ruby/10879) to configure it on awesomecode.io